### PR TITLE
Add custom domain support for kennethheine.com

### DIFF
--- a/infra/modules/static-web-app-with-domain.bicep
+++ b/infra/modules/static-web-app-with-domain.bicep
@@ -71,7 +71,10 @@ resource customDomain 'Microsoft.Web/staticSites/customDomains@2024-04-01' = if 
   name: customDomainName
   parent: staticWebApp
   properties: {
-    validationMethod: 'cname-delegation'
+    // Apex domains (like kennethheine.com) must use dns-txt-token validation
+    // Subdomains (like www.kennethheine.com) can use cname-delegation
+    // Apex domain detection: split by '.' and check if it has exactly 2 parts (domain.tld)
+    validationMethod: length(split(customDomainName, '.')) == 2 ? 'dns-txt-token' : 'cname-delegation'
   }
 }
 
@@ -82,11 +85,19 @@ output defaultHostname string = staticWebApp.properties.defaultHostname
 output repositoryUrl string = staticWebApp.properties.repositoryUrl
 output branch string = staticWebApp.properties.branch
 output customDomainName string = !empty(customDomainName) ? customDomainName : ''
-output customDomainValidationToken string = !empty(customDomainName) ? customDomain.properties.domainName : ''
+output customDomainValidationToken string = !empty(customDomainName) ? customDomain.properties.validationToken : ''
+output customDomainValidationMethod string = !empty(customDomainName) ? customDomain.properties.validationMethod : ''
 
 // Note: Deployment token should be retrieved dynamically using Azure CLI
 // az staticwebapp secrets list --name <app-name> --resource-group <rg-name> --query "properties.apiKey" --output tsv
 
-// Note: For custom domain setup, you'll need to:
-// 1. Create a CNAME record pointing your domain to the default hostname
-// 2. Azure will automatically validate the domain and issue an SSL certificate
+// Note: For custom domain setup:
+// APEX DOMAINS (like kennethheine.com):
+// 1. Create a TXT record with name "@" and value from the validation token
+// 2. Azure will validate the domain using DNS TXT record verification
+// 
+// SUBDOMAINS (like www.kennethheine.com):
+// 1. Create a CNAME record pointing to the default hostname
+// 2. Azure will validate using CNAME delegation
+//
+// SSL certificate will be automatically provisioned after validation

--- a/infra/modules/static-web-app-with-domain.bicep
+++ b/infra/modules/static-web-app-with-domain.bicep
@@ -86,7 +86,7 @@ output repositoryUrl string = staticWebApp.properties.repositoryUrl
 output branch string = staticWebApp.properties.branch
 output customDomainName string = !empty(customDomainName) ? customDomainName : ''
 output customDomainValidationToken string = !empty(customDomainName) ? customDomain.properties.validationToken : ''
-output customDomainValidationMethod string = !empty(customDomainName) ? customDomain.properties.validationMethod : ''
+// Note: validationMethod is write-only and cannot be output
 
 // Note: Deployment token should be retrieved dynamically using Azure CLI
 // az staticwebapp secrets list --name <app-name> --resource-group <rg-name> --query "properties.apiKey" --output tsv


### PR DESCRIPTION
## Overview
Adds custom domain support to the Azure Static Web App infrastructure to enable kennethheine.com as the primary domain.

## Changes Made
- ✅ Created new Bicep module \static-web-app-with-domain.bicep\ with custom domain support
- ✅ Updated \main.bicep\ to use the new module and include custom domain parameter
- ✅ Updated \production.bicepparam\ to configure \kennethheine.com\ as the custom domain
- ✅ **CRITICAL FIX**: Used \dns-txt-token\ validation for apex domains (kennethheine.com)
- ✅ Enhanced GitHub Actions workflow for better what-if output parsing
- ✅ Cleaned up unused files and fixed Bicep warnings

## Technical Details
- **Domain Type**: Apex domain (kennethheine.com)
- **Validation Method**: DNS TXT token (required for apex domains)
- **DNS Setup Required**: Create TXT record @ with validation token from Azure
- **SSL**: Automatically provisioned after domain validation

## Deployment Notes
After merging and deployment:
1. Get the validation token from Azure Static Web App
2. Create a TXT record in DNS with name \@\ and the token value
3. Azure will validate the domain and provision SSL certificate

## Testing
- ✅ Bicep template validation passed
- ✅ What-if analysis shows correct resource changes
- ✅ No Bicep warnings or errors